### PR TITLE
Make the README example work out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A DynECT REST client for the Go programming language.
 		}
 
 		for _, zone := range response.Data {
-			log.Println("Zone ", zone)
+			log.Println("Zone", zone)
 		}
 	}
 


### PR DESCRIPTION
It doesn't compile in it's current state, the two edits I've made fix that.
