### PR TITLE
Remove resp.ContentLength == -1 check

### DIFF
--- a/dynect/client.go
+++ b/dynect/client.go
@@ -167,7 +167,7 @@ func (c *Client) Do(method, endpoint string, requestData, responseData interface
 
 	switch resp.StatusCode {
 	case 200:
-		if resp.ContentLength == 0 || resp.ContentLength == -1 {
+		if resp.ContentLength == 0 {
 			// Zero-length content body?
 			log.Println("dynect: warning: zero-length response body; skipping decoding of response")
 			return nil

--- a/dynect/client.go
+++ b/dynect/client.go
@@ -156,6 +156,7 @@ func (c *Client) Do(method, endpoint string, requestData, responseData interface
 
 	var resp *http.Response
 	resp, err = c.transport.RoundTrip(req)
+
 	if err != nil {
 		if c.verbose {
 			respBody, _ := ioutil.ReadAll(resp.Body)

--- a/dynect/client_test.go
+++ b/dynect/client_test.go
@@ -2,15 +2,15 @@ package dynect
 
 import (
 	"os"
-	"testing"
 	"strings"
+	"testing"
 )
 
 var (
 	DynCustomerName string
 	DynUsername     string
 	DynPassword     string
-	testZone string
+	testZone        string
 )
 
 func init() {
@@ -94,7 +94,7 @@ func TestFetchingAllZoneRecords(t *testing.T) {
 	}()
 
 	var resp AllRecordsResponse
-	err = client.Do("GET", "AllRecord/" + testZone, nil, &resp)
+	err = client.Do("GET", "AllRecord/"+testZone, nil, &resp)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
It looks like -1 this is valid in this situation, from the net.http docs:

    // ContentLength records the length of the associated content.  The
    // value -1 indicates that the length is unknown.  Unless Request.Method
    // is "HEAD", values >= 0 indicate that the given number of bytes may
    // be read from Body.
    ContentLength int64

and the Dyn API isn't returning a Content-Length header. Tests pass with this change as does my [test program](https://github.com/wjessop/dyn_client_test).