### PR TITLE
Remove go-dynect logging prefix; which becomes global on import

### DIFF
--- a/dynect/client.go
+++ b/dynect/client.go
@@ -14,11 +14,6 @@ const (
 	DynAPIPrefix = "https://api.dynect.net/REST"
 )
 
-func init() {
-	// Set the logging prefix.
-	log.SetPrefix("go-dynect ")
-}
-
 // A client for use with DynECT's REST API.
 type Client struct {
 	Token        string


### PR DESCRIPTION
When importing go-dynect into another project, the init function is triggered and the `go-dynect` log prefix is set _globally_. This means that the prefix is used any time that application uses a `log.Print*()` call, not just in `go-dynect` calls.

The change I made is probably not a complete fix from your perspective but it at least prevents unexpected behavior in a consuming library / application. We ran into this issue while working on [Terraform](https://terraform.io). Thanks!