### PR TITLE
More explicit job handling in client + DSF

### DIFF
--- a/dynect/dsfs.go
+++ b/dynect/dsfs.go
@@ -1,0 +1,117 @@
+package dynect
+
+// DSFSResponse is used for holding the data returned by a call to
+// "https://api.dynect.net/REST/DSF/" with 'detail: Y'.
+type AllDSFDetailedResponse struct {
+	ResponseBlock
+	Data []DSFService `json:"data"`
+}
+
+// DSFResponse is used for holding the data returned by a call to
+// "https://api.dynect.net/REST/DSF/SERVICE_ID".
+type DSFResponse struct {
+	ResponseBlock
+	Data DSFService `json:"data"`
+}
+
+// Type DSFService is used as a nested struct, which holds the data for a
+// DSF Service returned by a call to "https://api.dynect.net/REST/DSF/SERVICE_ID".
+type DSFService struct {
+	ID            string       `json:"service_id"`
+	Label         string       `json:"label"`
+	Active        string       `json:"active"`
+	TTL           string       `json:"ttl"`
+	PendingChange string       `json:"pending_change"`
+	Notifiers     []Notifier   `json:"notifiers"`
+	Nodes         []DSFNode    `json:"nodes"`
+	Rulesets      []DSFRuleset `json:"rulesets"`
+}
+
+type DSFRuleset struct {
+	ID            string            `json:"dsf_ruleset_id`
+	Label         string            `json:"label"`
+	CriteriaType  string            `json:"criteria_type"`
+	Criteria      interface{}       `json:"criteria"`
+	Ordering      string            `json:"ordering"`
+	Eligible      string            `json:"eligible"`
+	PendingChange string            `json:"pending_change"`
+	ResponsePools []DSFResponsePool `json:"response_pools"`
+}
+
+type DSFResponsePool struct {
+	ID            string              `json:"dsf_response_pool_id"`
+	Label         string              `json:"label"`
+	Automation    string              `json:"automation"`
+	CoreSetCount  string              `json:"core_set_count"`
+	Eligible      string              `json:"eligible"`
+	PendingChange string              `json:"pending_change"`
+	RsChains      []DSFRecordSetChain `json:"rs_chains"`
+	Rulesets      []DSFRuleset        `json:"rulesets"`
+	Status        string              `json:"status"`
+	LastMonitored string              `json:"last_monitored"`
+	Notifier      string              `json:"notifier"`
+}
+
+type DSFRecordSetChain struct {
+	ID                string         `json:"dsf_record_set_failover_chain_id"`
+	Status            string         `json:"status"`
+	Core              string         `json:"core"`
+	Label             string         `json:"label"`
+	DSFResponsePoolID string         `json:"dsf_response_pool_id"`
+	DSFServiceID      string         `json:"service_id"`
+	PendingChange     string         `json:"pending_change"`
+	DSFRecordSets     []DSFRecordSet `json:"record_sets"`
+}
+
+type DSFRecordSet struct {
+	Status        string      `json:"status"`
+	Eligible      string      `json:"eligible"`
+	ID            string      `json:"dsf_record_set_id"`
+	MonitorID     string      `json:"dsf_monitor_id"`
+	Label         string      `json:"label"`
+	TroubleCount  string      `json:"trouble_count"`
+	Records       []DSFRecord `json:"records"`
+	FailCount     string      `json:"fail_count"`
+	TorpidityMax  string      `json:"torpidity_max"`
+	TTLDerived    string      `json:"ttl_derived"`
+	LastMonitored string      `json:"last_monitored"`
+	TTL           string      `json:"ttl"`
+	ServiceID     string      `json:"service_id"`
+	ServeCount    string      `json:"serve_count"`
+	Automation    string      `json:"automation"`
+	PendingChange string      `json:"pending_change"`
+}
+
+type DSFRecord struct {
+	Status         string   `json:"status"`
+	Endpoints      []string `json:"endpoints"`
+	RDataClass     string   `json:"rdata_class"`
+	Weight         int      `json:"weight"`
+	Eligible       string   `json:"eligible"`
+	ID             string   `json:"dsf_record_id"`
+	DSFRecordSetID string   `json:"dsf_record_set_id"`
+	//RData           interface{} `json:"rdata"`
+	EndpointUpCount int    `json:"endpoint_up_count"`
+	Label           string `json:"label"`
+	MasterLine      string `json:"master_line"`
+	Torpidity       int    `json:"torpidity"`
+	LastMonitored   int    `json:"last_monitored"`
+	TTL             string `json:"ttl"`
+	DSFServiceID    string `json:"service_id"`
+	PendingChange   string `json:"pending_change"`
+	Automation      string `json:"automation"`
+	ReponseTime     int    `json:"response_time"`
+	Publish         string `json:"publish",omit_empty`
+}
+
+type DSFNode struct {
+	Zone string `json:"zone"`
+	FQDN string `json:"fqdn"`
+}
+
+type Notifier struct {
+	ID         int    `json:"notifier_id"`
+	Label      string `json:"label"`
+	Recipients string `json:"recipients"`
+	Active     string `json:"active"`
+}

--- a/dynect/helpers.go
+++ b/dynect/helpers.go
@@ -1,0 +1,30 @@
+package dynect
+
+import "fmt"
+
+func GetAllDSFServicesDetailed(c *Client) (error, []DSFService) {
+	var dsfsResponse AllDSFDetailedResponse
+	requestData := struct {
+		Detail string `json:"detail"`
+	}{Detail: "Y"}
+
+	if err := c.Do("GET", "DSF", requestData, &dsfsResponse); err != nil {
+		return err, nil
+	}
+
+	return nil, dsfsResponse.Data
+}
+
+func GetDSFServiceDetailed(c *Client, id string) (error, DSFService) {
+	var dsfsResponse DSFResponse
+	requestData := struct {
+		Detail string `json:"detail"`
+	}{Detail: "Y"}
+
+	loc := fmt.Sprintf("DSF/%s", id)
+
+	if err := c.Do("GET", loc, requestData, &dsfsResponse); err != nil {
+		return err, DSFService{}
+	}
+	return nil, dsfsResponse.Data
+}

--- a/dynect/job.go
+++ b/dynect/job.go
@@ -1,0 +1,8 @@
+package dynect
+
+type JobData struct {
+	Status   string         `json:"status"`
+	Data     interface{}    `json:"data"`
+	ID       int            `json:"job_id"`
+	Messages []MessageBlock `json:"msgs"`
+}

--- a/dynect/json.go
+++ b/dynect/json.go
@@ -15,7 +15,7 @@ type LoginBlock struct {
 //
 // All response-type structs should include this as an anonymous/embedded field.
 type ResponseBlock struct {
-	Status   string         `json:"string"`
+	Status   string         `json:"status"`
 	JobId    int            `json:"job_id,omitempty"`
 	Messages []MessageBlock `json:"msgs,omitempty"`
 }


### PR DESCRIPTION
So, another try :)

For whatever reason, this cast:
```
-                               rb, ok := responseData.(ResponseBlock)
-                               if !ok {
-                                       // ???
-                                       return fmt.Errorf("failed to coerce response data")
-                               }
```

didn't work well, hence I created a separate struct to parse just that one particular use-case.

+DSF support (Traffic Directors)
