### PR TITLE
Added ability for Client to obey HTTP(S)_PROXY env variables

### DIFF
--- a/dynect/client.go
+++ b/dynect/client.go
@@ -57,7 +57,7 @@ type Client struct {
 func NewClient(customerName string) *Client {
 	return &Client{
 		CustomerName: customerName,
-		transport:    &http.Transport{},
+		transport:    &http.Transport{Proxy: http.ProxyFromEnvironment},
 	}
 }
 


### PR DESCRIPTION
Added ability for Client to obey HTTP(S)_PROXY env variables, ConvenientClient pending :)

I also noticed that I created DSFS utility functions in a different way than hooking them to ConvenientClient, apologies for that, I'll redo that in the next day or two and will submit another PR.

OTOH, I'm not sure what the benefit would be of having 2 clients? Why not hook it all just either on `Client` itself or the way I've done by accident, i.e. `PublishZone(client *Client, zone *Zone)`?
