### PR TITLE
Change NewConvenientClient to call NewClient

### DIFF
--- a/dynect/convenient_client.go
+++ b/dynect/convenient_client.go
@@ -3,7 +3,6 @@ package dynect
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"strconv"
 	"strings"
 )
@@ -15,11 +14,9 @@ type ConvenientClient struct {
 
 // NewConvenientClient Creates a new ConvenientClient
 func NewConvenientClient(customerName string) *ConvenientClient {
-	return &ConvenientClient{
-		Client{
-			CustomerName: customerName,
-			httpclient:   &http.Client{},
-		}}
+    return &ConvenientClient{
+        *NewClient(customerName),
+    }
 }
 
 // PublishZone Publish a specific zone and the changes for the current session


### PR DESCRIPTION
Without this change, the following nil dereference occurs due to how Client in NewConvenientClient is created:

```
client: &{Client:{Token: CustomerName:splunk httpclient:0xc420086db0 transport:<nil> verbose:false}}

Program received signal SIGSEGV, Segmentation fault.
0x00000000004cebf1 in net/http.(*Transport).RoundTrip (t=0x0, req=0xc4200f00f0, ~r1=0x4,
    ~r2=...) at /usr/local/go/src/net/http/transport.go:307
307             t.nextProtoOnce.Do(t.onceSetNextProtoDefaults)
```

I've only recently (the last day or two) picked up Golang. If something is not up to snuff, please let me know.