### PR TITLE
Add support for capturing Dyn Rate Limit requests

### DIFF
--- a/dynect/client.go
+++ b/dynect/client.go
@@ -19,6 +19,7 @@ const (
 var (
 	PollingInterval  = 1 * time.Second
 	ErrPromotedToJob = errors.New("promoted to job")
+	ErrRateLimited   = errors.New("too many requests")
 )
 
 // handleJobRedirect overrides the net/http.DefaultClient's redirection policy
@@ -256,6 +257,9 @@ func (c *Client) Do(method, endpoint string, requestData, responseData interface
 		}
 
 		return nil
+
+	case 429:
+		return ErrRateLimited
 	}
 
 	// If we got here, this means that the client does not know how to


### PR DESCRIPTION
Dyn is updating their Managed DNS API to include rate limiting for any requests that exceed their thresholds. It would be nice if the client could capture 429 HTTP responses and return them back to the application as an error.

[Source](https://help.dyn.com/managed-dns-api-rate-limit/)

