### PR TITLE
Fix ConvenientClient nil transport

### DIFF
--- a/dynect/client.go
+++ b/dynect/client.go
@@ -46,7 +46,6 @@ func handleJobRedirect(req *http.Request, via []*http.Request) error {
 type Client struct {
 	Token        string
 	CustomerName string
-	httpclient   *http.Client
 	transport    *http.Transport
 	verbose      bool
 }

--- a/dynect/convenient_client.go
+++ b/dynect/convenient_client.go
@@ -18,7 +18,7 @@ func NewConvenientClient(customerName string) *ConvenientClient {
 	return &ConvenientClient{
 		Client{
 			CustomerName: customerName,
-			httpclient:   &http.Client{},
+			transport:    &http.Transport{Proxy: http.ProxyFromEnvironment},
 		}}
 }
 


### PR DESCRIPTION
fixes #15 - ConvenientClient was broken by a more recent commit

this PR fixes it by correctly initializing the transport when creating the ConvenientClient