### PR TITLE
add support for ALIAS, MX, NS and SOA to ConvenientClient

### DIFF
--- a/dynect/convenient_client.go
+++ b/dynect/convenient_client.go
@@ -119,11 +119,20 @@ func (c *ConvenientClient) GetRecord(record *Record) error {
 	switch rec.Data.RecordType {
 	case "A", "AAAA":
 		record.Value = rec.Data.RData.Address
+	case "ALIAS":
+		record.Value = rec.Data.RData.Alias
 	case "CNAME":
 		record.Value = rec.Data.RData.CName
+	case "MX":
+		record.Value = fmt.Sprintf("%d %s", rec.Data.RData.Preference, rec.Data.RData.Exchange)
+	case "NS":
+		record.Value = rec.Data.RData.NSDName
+	case "SOA":
+		record.Value = rec.Data.RData.RName
 	case "TXT", "SPF":
 		record.Value = rec.Data.RData.TxtData
 	default:
+		fmt.Println("unknown response", rec)
 		return fmt.Errorf("Invalid Dyn record type: %s", rec.Data.RecordType)
 	}
 
@@ -138,9 +147,24 @@ func buildRData(r *Record) (DataBlock, error) {
 		rdata = DataBlock{
 			Address: r.Value,
 		}
+	case "ALIAS":
+		rdata = DataBlock{
+			Alias: r.Value,
+		}
 	case "CNAME":
 		rdata = DataBlock{
 			CName: r.Value,
+		}
+	case "MX":
+		rdata = DataBlock{}
+		fmt.Sscanf(r.Value, "%d %s", &rdata.Preference, &rdata.Exchange)
+	case "NS":
+		rdata = DataBlock{
+			NSDName: r.Value,
+		}
+	case "SOA":
+		rdata = DataBlock{
+			RName: r.Value,
 		}
 	case "TXT", "SPF":
 		rdata = DataBlock{

--- a/dynect/records.go
+++ b/dynect/records.go
@@ -40,6 +40,9 @@ type DataBlock struct {
 	// A, AAAA
 	Address string `json:"address,omitempty" bson:"address,omitempty"`
 
+	// ALIAS
+	Alias string `json:"alias,omitempty" bson:"alias,omitempty"`
+
 	// CERT, DNSKEY, DS, IPSECKEY, KEY, SSHFP
 	Algorithm string `json:"algorithm,omitempty" bson:"algorithm,omitempty"`
 


### PR DESCRIPTION
NOTE: this PR requires #16 to be merged before ConvenientClient will work at all

this PR adds support for ALIAS, MX, NS and SOA records to ConvenientClient

most of the RData fields were already there... only Alias required addition of an extra field

