### PR TITLE
Check for errors when reading the response body while in verbose mode

### DIFF
--- a/dynect/client.go
+++ b/dynect/client.go
@@ -156,7 +156,10 @@ func (c *Client) Do(method, endpoint string, requestData, responseData interface
 
 	if err != nil {
 		if c.verbose {
-			respBody, _ := ioutil.ReadAll(resp.Body)
+			respBody, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
 			log.Printf("%s", string(respBody))
 		}
 		return err


### PR DESCRIPTION
### Overview
Noticing panics whenever Dyn responds with a 500 when running in verbose mode. Believe the issue is an unchecked error which leads to a `nil pointer dereference`.

#### Stacktrace
```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x466418]

goroutine 50 [running]:
panic(0x667c40, 0xc420012060)
    /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/distil/plt_transfer/vendor/github.com/nesv/go-dynect/dynect.(*Client).Do(0xc420054900, 0x6b2ab2, 0x3, 0xc420364200, 0xe, 0x0, 0x0, 0x645e40, 0xc4202550a0, 0x0, ...)
    /home/go/src/github.com/distil/plt_transfer/vendor/github.com/nesv/go-dynect/dynect/client.go:160 +0x13d8
```