### PR TITLE
client: Expose HTTP transport for easier debugging

### DIFF
--- a/dynect/client.go
+++ b/dynect/client.go
@@ -46,7 +46,7 @@ func handleJobRedirect(req *http.Request, via []*http.Request) error {
 type Client struct {
 	Token        string
 	CustomerName string
-	transport    *http.Transport
+	Transport    http.RoundTripper
 	verbose      bool
 }
 
@@ -54,7 +54,7 @@ type Client struct {
 func NewClient(customerName string) *Client {
 	return &Client{
 		CustomerName: customerName,
-		transport:    &http.Transport{Proxy: http.ProxyFromEnvironment},
+		Transport:    &http.Transport{Proxy: http.ProxyFromEnvironment},
 	}
 }
 
@@ -152,7 +152,7 @@ func (c *Client) Do(method, endpoint string, requestData, responseData interface
 	}
 
 	var resp *http.Response
-	resp, err = c.transport.RoundTrip(req)
+	resp, err = c.Transport.RoundTrip(req)
 
 	if err != nil {
 		if c.verbose {
@@ -219,7 +219,7 @@ func (c *Client) Do(method, endpoint string, requestData, responseData interface
 		for {
 			select {
 			case <-time.After(PollingInterval):
-				resp, err := c.transport.RoundTrip(req)
+				resp, err := c.Transport.RoundTrip(req)
 				if err != nil {
 					return err
 				}

--- a/dynect/convenient_client.go
+++ b/dynect/convenient_client.go
@@ -18,7 +18,7 @@ func NewConvenientClient(customerName string) *ConvenientClient {
 	return &ConvenientClient{
 		Client{
 			CustomerName: customerName,
-			transport:    &http.Transport{Proxy: http.ProxyFromEnvironment},
+			Transport:    &http.Transport{Proxy: http.ProxyFromEnvironment},
 		}}
 }
 


### PR DESCRIPTION
This is to allow easier debugging by overriding transport with a custom one which logs HTTP request & response details, e.g. like here: https://github.com/terraform-providers/terraform-provider-github/blob/master/github/config.go#L31