### PR TITLE
Add support for QPS Reports

### DIFF
--- a/dynect/qps.go
+++ b/dynect/qps.go
@@ -1,0 +1,36 @@
+
+package dynect
+
+// QpsReportRequest is used to model the request data for a QPS Report
+// API documentation: https://help.dyn.com/create-qps-report-api/
+type QpsReportRequest struct {
+  // Required. The timestamp at the beginning of the report range
+  StartTs       int64       `json:"start_ts"`
+  // Required. The timestamp at the end of the report range
+  EndTs         int64       `json:"end_ts"`
+
+  // Fields by which to break down the data. Valid values are `hosts`, `rrecs`,
+  // and `zones`.
+  Breakdown     []string    `json:"breakdown"`
+
+  // Hostnames to include in the report. An individual item can begin with a ‘!’
+  // to indicate a value to exclude. Defaults to all record types.
+  Hosts         []string    `json:"hosts"`
+
+  // Record types to include in the report. An individual item can begin with a
+  // ‘!’ to indicate a value to exclude. Defaults to all record types.
+  RRecs         []string    `json:"rrecs"`
+
+  // Zones to include in the report. An empty list defaults to all zones.
+  Zones         []string    `json:"zones"`
+}
+
+
+// QpsReportResponse is used for holding the data returned by a call to
+// "https://api.dynect.net/REST/QPSReport/".
+type QpsReportResponse struct {
+  ResponseBlock
+  Data struct {
+    Csv     string    `json:"csv"`
+  }                   `json:"data"`
+}


### PR DESCRIPTION
Example usage:
```go
import (
    "fmt"
    "log"
    "time"

    "github.com/derekargueta/go-dynect/dynect"
)
const FIFTEEN_MINUTES int64 = 60 * 15
...
endTs := time.Now().Unix()
startTs := endTs - FIFTEEN_MINUTES

req := dynect.QpsReportRequest{}
req.Zones = []string{"mydomain.com"}
req.StartTs = startTs
req.EndTs = endTs

var qpsReportResponse dynect.QpsReportResponse
if err := dyn.Do("POST", "QPSReport/", req, &qpsReportResponse); err != nil {
    log.Fatal(err)
}
fmt.Println(qpsReportResponse.Data.Csv)
```

Example output:
```
Timestamp,Queries
1508273100,12236
1508273400,12224
1508273700,6928
```