### PR TITLE
Fix DataBlock MarshalJSON

### DIFF
--- a/dynect/records.go
+++ b/dynect/records.go
@@ -1,5 +1,7 @@
 package dynect
 
+import "encoding/json"
+
 // Type AllRecordsResponse is a struct for holding a list of all URIs returned
 // from an HTTP GET call to either https://api.dynect.net/REST/AllRecord/<zone>
 // or https://api/dynect.net/REST/AllRecord/<zone>/<FQDN>/.
@@ -168,4 +170,35 @@ type DataBlock struct {
 
 	// SRV
 	Weight string `json:"weight,omitempty" bson:"weight,omitempty"`
+}
+
+// MarshalJSON is used override the standard marshalling function
+// so that values of 0 for the preference and priority fields of DataBlock
+// are not stripped by the standard 'omitempty' functionality.
+// See https://golang.org/pkg/encoding/json/#Marshal
+func (db DataBlock) MarshalJSON() ([]byte, error) {
+	type Alias DataBlock
+	if db.Preference == 0 {
+		return json.Marshal(&struct {
+			Preference int `json:"preference"`
+			Alias
+		}{
+			Preference: db.Preference,
+			Alias:      (Alias)(db),
+		})
+	}
+	if db.Priority == 0 {
+		return json.Marshal(&struct {
+			Priority int `json:"priority"`
+			Alias
+		}{
+			Priority: db.Priority,
+			Alias:    (Alias)(db),
+		})
+	}
+	return json.Marshal(&struct {
+		Alias
+	}{
+		Alias: (Alias)(db),
+	})
 }


### PR DESCRIPTION
With the current implementation, we are unable to create MX records with a preference of `0`, and SRV records with a priority of `0`.

From the [encoding/json](https://golang.org/pkg/encoding/json/#Marshal) docs:
```
The "omitempty" option specifies that the field should be omitted from the encoding if the field
has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any empty array,
slice, map, or string.
```